### PR TITLE
Change shell name to BlueOS kernel

### DIFF
--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -16,7 +16,7 @@ use crate::COMMANDS;
 
 pub fn command(args: &[&str]) -> Result<(), String> {
     if args.is_empty() {
-        println!("BlueKernel shell commands:");
+        println!("BlueOS kernel shell commands:");
         for (name, cmdinfo) in COMMANDS.entries() {
             println!("  {:<10} - {}", name, cmdinfo.description);
         }


### PR DESCRIPTION
Description: Change shell name to BlueOS kernel

Reason: Change shell name to BlueOS kernel

Issue: NA